### PR TITLE
docs: README에 AWS 비용 예측 문서 링크 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,8 @@ npm run test:search
 
 ## 📝 참고 자료
 
+- [API 사용 가이드](docs/api.md) - 모든 엔드포인트 상세 설명
+- [AWS 비용 예측 가이드](docs/aws-cost-estimation.md) - 시나리오별 AWS 배포 비용 예측 (개발/소규모/중규모/대규모)
 - [Elasticsearch Nori Plugin](https://www.elastic.co/guide/en/elasticsearch/plugins/current/analysis-nori.html)
 - [NestJS Documentation](https://docs.nestjs.com/)
 - [Elasticsearch Guide](https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html)


### PR DESCRIPTION
## 개요
README의 참고 자료 섹션에 AWS 비용 예측 문서 링크를 추가했습니다.

## 변경사항
- ✅ README.md 참고 자료 섹션에 AWS 비용 예측 가이드 링크 추가
- ✅ API 가이드 링크도 함께 추가하여 문서 구조 개선
- ✅ 각 링크에 간단한 설명 추가

## 추가된 내용
```markdown
- [API 사용 가이드](docs/api.md) - 모든 엔드포인트 상세 설명
- [AWS 비용 예측 가이드](docs/aws-cost-estimation.md) - 시나리오별 AWS 배포 비용 예측 (개발/소규모/중규모/대규모)
```

## 기대 효과
- 📚 사용자가 AWS 배포 시 예상 비용을 쉽게 확인 가능
- 🔍 문서 접근성 향상
- 📖 4가지 시나리오(개발/테스트, 소규모, 중규모, 대규모) 정보 제공

## 관련 이슈
Closes #26

## 체크리스트
- [x] README.md에 AWS 비용 예측 문서 링크 추가
- [x] 문서 링크가 올바르게 작동하는지 확인
- [x] 설명이 명확하고 간결한지 확인
- [x] 다른 문서 링크와 일관된 포맷 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)